### PR TITLE
Add pickup drop to tokens with bases

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -2133,6 +2133,10 @@ function setTokenBase(token, options) {
 		else{
 			token.children(".base").toggleClass("nohpaura", false);
 		}
+		token.toggleClass("hasbase", true);
+	}
+	else{
+		token.toggleClass("hasbase", false);
 	}
 
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3916,6 +3916,15 @@ button.avtt-roll-button {
 .token>.base.water-base{
     background-image: url(https://opengameart.org/sites/default/files/Untitled-3_1.jpg);
 }
+.token.hasbase:active .base{
+    filter: drop-shadow(3px 3px 2px #000000dd)
+}
+.token.hasbase:active .base.large-or-smaller-base{
+    filter: drop-shadow(1px 1px 2px #000000dd)
+}
+.token.hasbase:active{
+    transform: translate(-1px, -1px)
+}
 
 #tokenWrapper__tokenStyleSelect,
 #tokenWrapper__tokenBaseStyleSelect{


### PR DESCRIPTION
Add a small pickup/drop to the virtual minis. This shouldn't cause them to leave their square since we made them slightly smaller then their square.