### PR TITLE
Dead indication in combat tracker and definitely not a token token

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -307,7 +307,12 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		
 		hp=$("<div class='hp'/>");
 		hp.text(token.options.hp);
-		
+		if(hp.text() === '0'){
+			entry.toggleClass("ct_dead", true);
+		}
+		else{
+			entry.toggleClass("ct_dead", false);
+		}
 		hp.css('font-size','11px');
 		//hp.css('width','20px');
 		if(window.DM || !(token.options.monster > 0) )

--- a/Settings.js
+++ b/Settings.js
@@ -618,7 +618,6 @@ function update_token_base_visibility(container) {
 		findOtherOption("disablestat").hide();
 		findOtherOption("disableborder").hide();
 		findOtherOption("disableaura").hide();
-		findOtherOption("revealname").hide();
 		findOtherOption("hidehpbar").hide();
 		findOtherOption("enablepercenthpbar").hide();
 		findOtherOption("player_owned").hide();
@@ -628,7 +627,6 @@ function update_token_base_visibility(container) {
 		findOtherOption("disablestat").show();
 		findOtherOption("disableborder").show();
 		findOtherOption("disableaura").show();
-		findOtherOption("revealname").show();
 		findOtherOption("hidehpbar").show();
 		findOtherOption("enablepercenthpbar").show();
 		findOtherOption("player_owned").show();

--- a/Settings.js
+++ b/Settings.js
@@ -9,7 +9,9 @@ function token_setting_options() {
 				{ value: "square", label: "Square", description: `The token is square and is contained within the border. We set "Ignore Aspect Ratio" to true and "Square" to true. Great for tokens with a portrait art style!` },
 				{ value: "virtualMiniCircle", label: "Virtual Mini w/ Round Base", description: `The token looks like a physical mini with a round base. The image will show up as it is naturally with the largest side being equal to the token size, we set "Ignore Aspect Ratio" to false and "Square" to true. We also add a virtual token base to this Style with Borders and Health Aura on the base of the token. Great for tokens with a top-down art style!` },
 				{ value: "virtualMiniSquare", label: "Virtual Mini w/ Square Base", description: `The token looks like a physical mini with a round base. The image will show up as it is naturally with The largest side being equal to the token size, we set "Ignore Aspect Ratio" to false and "Square" to true. We also add a virtual token base to this Style with Borders and Health Aura on the base of the token. Great for tokens with a top-down art style!` },
-				{ value: "noConstraint", label: "No Constraint", description: `The token will show up as it is naturally largest side being equal to token size, we set "Ignore Aspect Ratio" to false and "Square to true. Borders and Health Aura are drawn as a drop shadow to fit the shape of the token.` }
+				{ value: "noConstraint", label: "No Constraint", description: `The token will show up as it is naturally largest side being equal to token size, we set "Ignore Aspect Ratio" to false and "Square to true. Borders and Health Aura are drawn as a drop shadow to fit the shape of the token.` },
+				{ value: "definitelyNotAToken", label: "Definitely Not a Token", description: `This token will have the shape of no contraints and be made too appear as a object tile` }
+			
 			],
 			defaultValue: "circle"
 		},
@@ -600,7 +602,8 @@ function update_token_base_visibility(container) {
 	let styleSubSelect = findOtherOption("tokenBaseStyleSelect");
 	if(selectedStyle === "virtualMiniCircle" || selectedStyle === "virtualMiniSquare"){
 		styleSubSelect.show();
-	} else{
+	} 
+	else{
 		styleSubSelect.hide();
 	}
 	if (selectedStyle === "noConstraint") {
@@ -609,6 +612,26 @@ function update_token_base_visibility(container) {
 	} else {
 		findOtherOption("square").hide();
 		findOtherOption("legacyaspectratio").hide();
+	}
+	if(selectedStyle == "definitelyNotAToken"){
+		findOtherOption("restrictPlayerMove").hide();
+		findOtherOption("disablestat").hide();
+		findOtherOption("disableborder").hide();
+		findOtherOption("disableaura").hide();
+		findOtherOption("revealname").hide();
+		findOtherOption("hidehpbar").hide();
+		findOtherOption("enablepercenthpbar").hide();
+		findOtherOption("player_owned").hide();
+	} 
+	else{
+		findOtherOption("restrictPlayerMove").show();
+		findOtherOption("disablestat").show();
+		findOtherOption("disableborder").show();
+		findOtherOption("disableaura").show();
+		findOtherOption("revealname").show();
+		findOtherOption("hidehpbar").show();
+		findOtherOption("enablepercenthpbar").show();
+		findOtherOption("player_owned").show();
 	}
 }
 

--- a/Token.js
+++ b/Token.js
@@ -660,6 +660,12 @@ class Token {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'visible');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'visible');
 		}
+		if($("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").text() === '0'){
+			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").toggleClass("ct_dead", true);
+		}
+		else{
+			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").toggleClass("ct_dead", false);
+		}
 		
 		if (this.options.hidden == false || typeof this.options.hidden == 'undefined'){
 			console.log("Setting combat tracker opacity to 1.0")
@@ -2110,13 +2116,22 @@ function setTokenBase(token, options) {
 		token.children("img").css("border-radius", "0");
 		token.children("img").removeClass("preserve-aspect-ratio");
 	}
-	else if(options.tokenStyleSelect === "noConstraint") {
+	else if(options.tokenStyleSelect === "noConstraint" || options.tokenStyleSelect === "definitelyNotAToken") {
 		//Freeform
 		options.square = true;
 		options.legacyaspectratio = false;
+		if(options.tokenStyleSelect === "definitelyNotAToken"){
+			options.restrictPlayerMove = true;
+			options.disablestat = true;
+			options.disableborder = true;
+			options.disableaura = true;
+			options.revealname = false;
+		}
+
 		token.children("img").css("border-radius", "0");
 		token.children("img").addClass("preserve-aspect-ratio");
 		token.children("img").toggleClass("freeform", true);
+
 	}
 	else if(options.tokenStyleSelect === "virtualMiniCircle"){
 		$(`.token[data-id='${options.id}']`).prepend(base);

--- a/Token.js
+++ b/Token.js
@@ -1091,26 +1091,20 @@ class Token {
 	
 			setTimeout(function() {old.find("img").css("transition", "")}, 200);
 			
-			if (old.attr('name') != this.options.name) {
-				var selector = "tr[data-target='"+this.options.id+"']";
-				var entry = $("#combat_area").find(selector);
-				if (old.addClass('hasTooltip') && (!(this.options.name) || !(this.options.revealname))) {
-					old.removeClass('hasTooltip');
-						entry.removeClass("hasTooltip");
-				}	
-				if (this.options.name) {
-					if ((window.DM || !this.options.monster || this.options.revealname)) {
-						old.attr("data-name", this.options.name);
-						old.addClass("hasTooltip");
-							entry.attr("data-name", this.options.name);
-							entry.addClass("hasTooltip");
-					}
+			var selector = "tr[data-target='"+this.options.id+"']";
+			var entry = $("#combat_area").find(selector);
+			if(!(this.options.name) || !(this.options.revealname)) {
+				old.toggleClass('hasTooltip', false);
+				entry.toggleClass('hasTooltip', false);
+			}	
+			else if (this.options.name) {
+				if ((window.DM || !this.options.monster || this.options.revealname)) {
+					old.attr("data-name", this.options.name);
+					old.toggleClass('hasTooltip', true);
+					entry.attr("data-name", this.options.name);
+					entry.toggleClass('hasTooltip', true);
 				}
 			}
-
-
-
-
 
 
 			if (old.attr('width') !== this.sizeWidth() || old.attr('height') !== this.sizeHeight()) {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -854,7 +854,9 @@ div#scene_properties form > div {
     right: 0;
     bottom: 0;
     z-index: 2;
+    pointer-events: none;
 }
+
 
 .dead:before, .dead:after {
     position: absolute;
@@ -876,6 +878,42 @@ div#scene_properties form > div {
 .dead:after {
     -webkit-transform: rotate(45deg);
     transform: rotate(45deg);
+}
+.ct_dead img{
+    filter: saturate(0);
+}
+.ct_dead .hp,
+.ct_dead .max_hp{
+    color: #bc0f0f;
+}
+#combat_area .ct_dead[data-current][data-target*="characters"]{
+    background: none;
+}
+.ct_dead:not([data-target*="characters"]) .delSVG path:not([fill*="none"]){
+    fill: #ff4848;
+    opacity: 0.7;
+}
+.ct_dead[data-current]:not([data-target*="characters"]) path:not([fill*="none"]){
+    fill: #ff4848;
+    opacity: 1;
+}
+#combat_area .ct_dead[data-current] input{
+    border-color: #bc0f0f;
+}
+
+.ct_dead[data-current]{
+    animation:  deadCombatGlow 3s ease-in-out infinite alternate;
+}
+
+@keyframes deadCombatGlow{
+    0%, 100%{
+        box-shadow: inset 0px 0px 25px 0px #bc0f0f;
+        filter: saturate(0.7);
+    }
+    50%{
+        box-shadow: inset 0px 0px 25px 2px #bc0f0f;
+        filter: saturate(1);
+    }
 }
 
 #combat_tracker {


### PR DESCRIPTION
This adds adds 0 health indication to the combat tracker and a definitely not a token style for objects. The definitely not a token style hides other options that wouldn't be applicable to an object. This object should only be interactable by the DM to start and can be locked or hidden. 

Also a bug fix for name reveal toggle. It wasn't working on custom tokens at minimum (I didn't test them all till already fixing it)

https://user-images.githubusercontent.com/65363489/176771959-9ceffccc-bc74-44e1-8453-dc88587ddf9a.mp4

https://user-images.githubusercontent.com/65363489/176776501-b6372f29-4eb5-4bc1-b222-46ed3d8d0203.mp4



