### PR TITLE
Missed option to hide for not a token

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -621,6 +621,7 @@ function update_token_base_visibility(container) {
 		findOtherOption("hidehpbar").hide();
 		findOtherOption("enablepercenthpbar").hide();
 		findOtherOption("player_owned").hide();
+		findOtherOption("hidestat").hide();
 	} 
 	else{
 		findOtherOption("restrictPlayerMove").show();
@@ -630,6 +631,7 @@ function update_token_base_visibility(container) {
 		findOtherOption("hidehpbar").show();
 		findOtherOption("enablepercenthpbar").show();
 		findOtherOption("player_owned").show();
+		findOtherOption("hidestat").show();
 	}
 }
 


### PR DESCRIPTION
Missed hiding the show HP to other players option for the not a token style. 

I don't think people will use this setting on PC's and it disables HP anyway. It looks weird to be there in overrides.