### PR TITLE
Fix: Selection drag being interrupted by tokens and select tokens partially selected

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -864,6 +864,7 @@ function drawing_mousedown(e) {
 		context.setLineDash([10, 5])
 		if (e.which == 1) {
 			$("#temp_overlay").css('cursor', 'crosshair');
+			$("#temp_overlay").css('z-index', '50');
 		}		
 	}
 	// figure out what these 3 returns are supposed to be for.
@@ -1243,11 +1244,15 @@ function drawing_mouseup(e) {
 		for (id in window.TOKEN_OBJECTS) {
 			var curr = window.TOKEN_OBJECTS[id];
 			var toktop = parseInt(curr.options.top);
-			if ((Math.min(window.BEGIN_MOUSEY, mouseY, toktop)) == toktop || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
-				continue;
 			var tokleft = parseInt(curr.options.left);
-			if ((Math.min(window.BEGIN_MOUSEX, mouseX, tokleft)) == tokleft || (Math.max(window.BEGIN_MOUSEX, mouseX, tokleft) == tokleft))
+			var tokright = tokleft + parseInt(curr.options.size);
+			var tokbottom = toktop + parseInt(curr.options.size);
+
+			if ((Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom)) == tokbottom || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
 				continue;
+			if ((Math.min(window.BEGIN_MOUSEX, mouseX, tokright)) == tokright || (Math.max(window.BEGIN_MOUSEX, mouseX, tokleft) == tokleft))
+				continue;
+
 			c++;
 			// TOKEN IS INSIDE THE SELECTION
 			if (window.DM || !curr.options.hidden) {
@@ -1259,7 +1264,7 @@ function drawing_mouseup(e) {
 			}
 			
 		}
-
+		$("#temp_overlay").css('z-index', '25');
 		window.MULTIPLE_TOKEN_SELECTED = (c > 1);
 
 		redraw_fog();


### PR DESCRIPTION
This fixes the selection drag bug overtop tokens.

This also changes the select to select tokens that base/size/controlled area is partially selected. The only time a partial selection won't select a token is if the token is scaled out of it's boundaries. Such as the roc's wing in this example. If we want that I can figure that out later. I think this is still an improvement for the time being though.

Example: https://www.youtube.com/watch?v=IMn6eQwhBXg