### PR TITLE
Fix: draw menu color not selectable and set color on click out so that it doesn't draw one of the color and swap back

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1923,7 +1923,7 @@ function init_draw_menu(buttons){
 		type: "color",
 		showInput: true,
 		showInitial: true,
-		clickoutFiresChange: false
+		clickoutFiresChange: true
 	});
 
     const colorPickerChange = function(e, tinycolor) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -109,8 +109,8 @@ function token_context_menu_expanded(tokenIds, e) {
 		$("#tokenOptionsPopup").remove();
 		$('.context-menu-list').trigger('contextmenu:hide')
 		tokenOptionsClickCloseDiv.remove();
-		$(".sp-container").spectrum("destroy");
-		$(".sp-container").remove();
+		$("#tokenOptionsContainer .sp-container").spectrum("destroy");
+		$("#tokenOptionsContainer .sp-container").remove();
 		$(`.context-menu-flyout`).remove(); 
 	});
 


### PR DESCRIPTION
Fixes the draw menu color being not selectedable.

Narrowed this down to the right click menu. So the destroy/remove should only target the menu ones now. 

Also sets the draw color on clicking out of the color picker. It would draw one shape the new color before swapping back otherwise.