### PR TITLE
Fix to allow names to be displayed on disabled 'object' style tokens and disable context menu for players on locked tokens

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1958,6 +1958,8 @@ function token_menu() {
 			console.log("context_menu_flyout contextmenu event", event);
 			event.preventDefault();
 			event.stopPropagation();
+			if($(event.currentTarget).children('.token-image').css('pointer-events') == 'none' && !window.DM)
+				return;
 			if ($(event.currentTarget).hasClass("tokenselected") && window.CURRENTLY_SELECTED_TOKENS.length > 0) {
 				token_context_menu_expanded(window.CURRENTLY_SELECTED_TOKENS, event);
 			} else {
@@ -2119,7 +2121,6 @@ function setTokenBase(token, options) {
 			options.disablestat = true;
 			options.disableborder = true;
 			options.disableaura = true;
-			options.revealname = false;
 			options.enablepercenthpbar = false;
 		}
 


### PR DESCRIPTION
Fix to allow the names toggle to work for object

https://www.youtube.com/watch?v=trDrdRzCBx8

Also disables the context menu for players on locked (disabled all interaction) tokens.