### PR TITLE
Clear tokens_needing_updates, make sure token is updated, and prevent attempts to set window.pc on tabs/iframes

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -18,13 +18,13 @@ const sendCharacterUpdateEvent = mydebounce(() => {
       characterId: window.PLAYER_ID,
       pcData: pcData
     });
+    update_pc_with_data(window.PLAYER_ID, pcData);
   } else {
     tabCommunicationChannel.postMessage({
       characterId: window.location.href.split('/').slice(-1)[0],
       pcData: pcData
     });
   }
-  update_pc_with_data(window.PLAYER_ID, pcData);
 }, 1500);
 
 /** @param changes {object} the changes that were observed. EX: {hp: 20} */

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -536,8 +536,9 @@ function update_pc_with_data(playerId, data) {
 const debounce_pc_token_update = mydebounce(() => {
   if (window.DM) {
     window.PC_TOKENS_NEEDING_UPDATES.forEach((playerId) => {
-      let token = window.TOKEN_OBJECTS[playerId];
+     
       const pc = find_pc_by_player_id(playerId, false);
+      let token = window.TOKEN_OBJECTS[pc.sheet];
       if (token && pc) {
         token.options = {
           ...token.options,
@@ -548,6 +549,7 @@ const debounce_pc_token_update = mydebounce(() => {
       }
       update_pc_token_rows();
     });
+    window.PC_TOKENS_NEEDING_UPDATES = [];
   }
 });
 


### PR DESCRIPTION
Couple fixes I mentioned in discord.

This clears pc's that need updating so we don't end up compounding out messages.

Makes sure the token is updated by getting the id from the pc data - since the playerId is not the full id needed for window.token_objects.

Stop trying to set window.pcs data in iframes or tabs as they don't/shouldn't have that data.