### PR TITLE
Add source links to notes

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -551,6 +551,10 @@ class JournalManager{
 			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto; min-height: 100%;");
 			$(this).siblings(".ui-dialog-titlebar").children(".ui-dialog-titlebar-close").click();
 		});
+		note.off('click').on('click', '.int_source_link', function(event){
+			event.preventDefault();
+			render_source_chapter_in_iframe(event.target.href);
+		});
 	}
 	
 	note_visibility(id,visibility){
@@ -663,12 +667,15 @@ class JournalManager{
 			plugins: 'save,hr,image,link,lists,media,paste,tabfocus,textcolor,colorpicker,autoresize, code, table',
 			toolbar1: 'undo styleselect | hr | bold italic underline strikethrough | alignleft aligncenter alignright justify| outdent indent | bullist numlist | forecolor backcolor | fontsizeselect | link unlink | image media | table | code',
 			image_class_list: [
-				{title: 'None', value: ''},
 				{title: 'Magnify', value: 'magnify'},
 			],
 			external_plugins: {
 				'image': "/content/1-0-1688-0/js/tinymce/tiny_mce/plugins/image/plugin.min.js",
 			},
+			link_class_list: [
+			   {title: 'External Link', value: 'ext_link'},
+			   {title: 'DNDBeyond Source Link', value: 'int_source_link'}
+			],
 			relative_urls : false,
 			remove_script_host : false,
 			convert_urls : true,

--- a/Main.js
+++ b/Main.js
@@ -1134,6 +1134,10 @@ function init_controls() {
 		sidebarControls.addClass("player");
 	}
 	addGamelogPopoutButton()
+	$('ol[class*="GameLogEntries"]').off('click').on('click', '.int_source_link', function(event){
+		event.preventDefault();
+		render_source_chapter_in_iframe(event.target.href);
+	});
 }
 
 const MAX_ZOOM_STEP = 20

--- a/Token.js
+++ b/Token.js
@@ -1324,8 +1324,12 @@ class Token {
 					            });
 					            flyout.append(buttonFooter);
 					            buttonFooter.append(sendToGamelogButton);
-
-					      
+					            flyout.find("a").attr("target","_blank");
+					      		flyout.off('click').on('click', '.int_source_link', function(event){
+									event.preventDefault();
+									render_source_chapter_in_iframe(event.target.href);
+								});
+								
 
 					            flyout.hover(function (hoverEvent) {
 					                if (hoverEvent.type === "mouseenter") {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5991,6 +5991,15 @@ div.note[id^="ui-id"] .mce-btn button {
     background-color: #fff;
 }
 
+
+#journal-panel .reorder-button{
+    display: inline;
+}
+#ddb-source-journal-import{
+    display:inline;
+    float:right;
+    width:175px;
+}
 .body-rpgcharacter-sheet #VTT.paused *{
     pointer-events: none !important;
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6301,6 +6301,8 @@ button.journal-view-button.journal-button {
 /* START - New quote box implementation */
 [class*='MessageContainer'] .tooltip-body{
     padding: 0px;
+    width: 265px;
+    overflow-wrap: anywhere;
 }
 
 


### PR DESCRIPTION
Adds a link type for source links.

https://cdn.discordapp.com/attachments/930926587392692335/1097082075305226280/links_in_notes.gif

I also got set it for hover notes and the gamelog here. And include a bug fix for notes overflowing the gamelog container/not wrapping.
![hover notes and gamelog](https://user-images.githubusercontent.com/65363489/232290223-e367f6c9-09a1-45a2-b708-bd2460f3f528.gif)

